### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core2"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 description = "The bare essentials of std::io for use in no_std. Alloc support is optional."
 license = "Apache-2.0 OR MIT"

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@
 // coherence challenge (e.g., specialization, neg impls, etc) we can
 // reconsider what crate these items belong in.
 
+#[allow(deprecated)]
 use core::alloc::LayoutErr;
 
 use core::any::TypeId;
@@ -322,6 +323,7 @@ impl<'a> From<Cow<'a, str>> for Box<dyn Error> {
 #[cfg(feature = "nightly")]
 impl Error for ! {}
 
+#[allow(deprecated)]
 impl Error for LayoutErr {}
 
 impl Error for core::str::ParseBoolError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", allow(dead_code))]
 
+#[cfg(not(feature = "std"))]
 pub mod error;
+
+#[cfg(feature = "std")]
+pub use std::error as error;
+
+#[cfg(not(feature = "std"))]
 pub mod io;
+
+#[cfg(feature = "std")]
+pub use std::io as io;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
Re-exports std::io and std::error in 'std' feature